### PR TITLE
Can't use default if it's not str when reading as str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Upcoming
+## [0.1.1]
+
+### Fixed
+
+- If a field is not a string but should be read as a string (and later converted).
+  If that field is missing rather than using the default value it would crash [#3](https://github.com/Senth/blulib/issues/3)
+
+## [0.1.0]
 
 ### Added
+
+- Config parser to easily parse ini/cfg files into objects.

--- a/blulib/config_parser/config_parser.py
+++ b/blulib/config_parser/config_parser.py
@@ -53,7 +53,7 @@ class ConfigParser(configparser.ConfigParser):
         default = getattr(object, key_info.object_key)
         get_func = getattr(section, key_info.function_name)
         value = get_func(key_info.config_key, fallback=default)
-        if key_info.type == "str":
+        if isinstance(value, str):
             value = ConfigParser._strip_quotes(value)
         setattr(object, key_info.object_key, value)
 

--- a/blulib/config_parser/config_parser_test.py
+++ b/blulib/config_parser/config_parser_test.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pathlib import Path
 from typing import Any, List
 
@@ -18,7 +19,7 @@ def parser() -> ConfigParser:
 class Object:
     def __init__(
         self,
-        str_value: str = "",
+        str_value: Any = "",
         str_list: List[str] = [],
         int_value: int = 0,
         int_list: List[int] = [],
@@ -89,7 +90,7 @@ class Object:
             Object(),
             "bool test",
             ["bool:bool_value", "bool_list:bool_list"],
-            Object(bool_value=True, bool_list=[True, False, True, False, True, False, True, False]),
+            Object(bool_value=True, bool_list=[True, False, True, False, True, False, True, False, True, False]),
         ),
         (
             "Should use default value from object when the key is missing",
@@ -132,3 +133,25 @@ def test_to_object(
     else:
         parser.to_object(object, section, *keys)
         assert expected == object
+
+
+class StrEnum(Enum):
+    test = "test"
+
+
+class ContainsEnum:
+    def __init__(self) -> None:
+        self.use_default = StrEnum.test
+        self.replaced = StrEnum.test
+
+
+def test_to_object_read_str_but_is_object(parser: ConfigParser) -> None:
+    expected = {
+        "use_default": StrEnum.test,
+        "replaced": "hello",
+    }
+    actual = ContainsEnum()
+    parser.to_object(actual, "enum as string", "use_default", "replaced")
+
+    assert expected["use_default"] == actual.use_default
+    assert expected["replaced"] == actual.replaced

--- a/fixtures/config_parser.cfg
+++ b/fixtures/config_parser.cfg
@@ -33,6 +33,12 @@ bool_list =
   false
   yes
   no
+  "True"
+  "False"
 
 [missing key test]
 # missing key = should be default
+
+[enum as string]
+replaced = hello
+# 'use_default' is missing so should use default


### PR DESCRIPTION
### What changed?

- Checks if the value is a string before trying to remove any quotes.

### Testing

- [X] Added unit tests

### Safety checklist

- [ ] I have reviewed my own code

### Related Issues

Fixes #3
